### PR TITLE
Static linking: macos, linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It also has two interesting methods:
 - SendAndCatch()
 
 # Linking statically against TDLib
-I recommend you to link it statically if you don't want compile TDLib on production (don't forget that it requires at least 8GB of RAM). To do that, just replace `//#cgo linux LDFLAGS: -L/usr/local/lib -ltdjson` with `//#cgo linux LDFLAGS: -L/usr/local/lib -ltdjson_static -ltdjson_private -ltdclient -ltdcore -ltdactor -ltddb -ltdsqlite -ltdnet -ltdutils -lstdc++ -lssl -lcrypto -ldl -lz -lm`. For more details read this issue: https://github.com/tdlib/td/issues/8
+I recommend you to link it statically if you don't want compile TDLib on production (don't forget that it requires at least 8GB of RAM). 
+<br/>To do that, just build your source with tag `tdjson_static`: `go build -tags tdjson_static`
+<br />For more details read this issue: https://github.com/tdlib/td/issues/8
 
 # Example
 ```golang

--- a/tdjson.go
+++ b/tdjson.go
@@ -1,8 +1,11 @@
 package tdjson
 
 //#cgo linux CFLAGS: -I/usr/local/include
+//#cgo darwin CFLAGS: -I/usr/local/include
 //#cgo windows CFLAGS: -IC:/src/td -IC:/src/td/build
-//#cgo linux LDFLAGS: -L/usr/local/lib -ltdjson
+//#cgo linux,!tdjson_static LDFLAGS: -L/usr/local/lib -ltdjson
+//#cgo linux,tdjson_static LDFLAGS: -L/usr/local/lib -ltdjson_static -ltdjson_private -ltdclient -ltdcore -ltdactor -ltddb -ltdsqlite -ltdnet -ltdutils -lstdc++ -lssl -lcrypto -ldl -lz -lm
+//#cgo darwin LDFLAGS: -L/usr/local/lib -L/usr/local/opt/openssl/lib -ltdjson_static -ltdjson_private -ltdclient -ltdcore -ltdactor -ltddb -ltdsqlite -ltdnet -ltdutils -lstdc++ -lssl -lcrypto -ldl -lz -lm
 //#cgo windows LDFLAGS: -LC:/src/td/build/Debug -ltdjson
 //#include <stdlib.h>
 //#include <td/telegram/td_json_client.h>


### PR DESCRIPTION
I added static linking for macos and also added static linking for linux. Now if you want to compile project with static TDLib files you should add tag `tdjson_static` to build tags. By default project compiles with shared libs.